### PR TITLE
Icinga DB: Change log level to debug

### DIFF
--- a/services/icingadb.yml
+++ b/services/icingadb.yml
@@ -6,3 +6,5 @@ database:
   password: {{.Mysql.Password}}
 redis:
   address: {{.Redis.Host}}:{{.Redis.Port}}
+logging:
+  level: debug


### PR DESCRIPTION
This PR changes the logging level of Icinga DB to debug. This is needed because we changed the default log level of Icinga DB to info.