### PR TITLE
Set hostname in Icinga 2 containers

### DIFF
--- a/internal/services/icinga2/docker.go
+++ b/internal/services/icinga2/docker.go
@@ -60,8 +60,9 @@ func (i *dockerCreator) CreateIcinga2(name string) services.Icinga2Base {
 	}
 
 	cont, err := i.dockerClient.ContainerCreate(context.Background(), &container.Config{
-		Image: dockerImage,
-		Env:   []string{"ICINGA_MASTER=1"},
+		Image:    dockerImage,
+		Hostname: name,
+		Env:      []string{"ICINGA_MASTER=1"},
 	}, nil, &network.NetworkingConfig{
 		EndpointsConfig: map[string]*network.EndpointSettings{
 			networkName: {


### PR DESCRIPTION
As Icinga initializes it's NodeName and certificates from the hostname, this ensures that the given name is used instead of a random string.

Not yet relevant for any of the current Icinga DB tests but this will make my life easier for writing new ones.

### Before
```json
{
  "L": "DEBUG",
  "T": "2021-10-29T12:00:12.349+0200",
  "M": "container output",
  "icinga2": true,
  "container-name": "icinga-testing-d333c7f7-icinga2-1-master",
  "container-id": "06bb976d479faa571a4d9fc357775aaf78afb549882e363f6c838a9ca260be96",
  "line": "[2021-10-29 10:00:12 +0000] information/ApiListener: My API identity: 06bb976d479f"
}
```

### After
```json
{
  "L": "DEBUG",
  "T": "2021-10-29T12:03:17.088+0200",
  "M": "container output",
  "icinga2": true,
  "container-name": "icinga-testing-310d3349-icinga2-1-master",
  "container-id": "ae011a26375b1af4ab0f0ffbf4d360d7df3bfd846edcca08f916ecab6f14a750",
  "line": "[2021-10-29 10:03:17 +0000] information/ApiListener: My API identity: master"
}
```