### PR TITLE
Write database type to icingadb.yml

### DIFF
--- a/services/icingadb.yml
+++ b/services/icingadb.yml
@@ -1,4 +1,5 @@
 database:
+  type: mysql
   host: {{.Mysql.Host}}
   port: {{.Mysql.Port}}
   database: {{.Mysql.Database}}


### PR DESCRIPTION
Required for https://github.com/Icinga/icingadb/pull/221

### Blocked by
* #7 (not technically a requirement but that code is already used by the tests in the current Icinga DB master branch, so it is included here to allow using this branch for testing without further merges)