### PR TITLE
Reduce Icinga DB logging interval

### DIFF
--- a/services/icingadb.yml
+++ b/services/icingadb.yml
@@ -8,3 +8,4 @@ redis:
   address: {{.Redis.Host}}:{{.Redis.Port}}
 logging:
   level: debug
+  interval: 1s


### PR DESCRIPTION
For tests, it's helpful to have more frequent logging than only every 20s (default for interval).