### PR TITLE
 Add util to log the result of SQL queries for debugging

### DIFF
--- a/utils/database.go
+++ b/utils/database.go
@@ -1,0 +1,85 @@
+package utils
+
+import (
+	"bytes"
+	"database/sql"
+	"encoding/hex"
+	"fmt"
+	"strconv"
+)
+
+// DB is an interface that contains functions provided by *database/sql.DB and *github.com/jmoiron/sqlx.DB required by
+// functions in this package so that in can be used with both.
+type DB interface {
+	Query(query string, args ...interface{}) (*sql.Rows, error)
+}
+
+// PrettySelect performs a query on the given database connection, retrieves the result set, pretty-prints it and
+// returns the result as a string suitable for writing into a log for debugging.
+//
+// Example usage:
+//
+//     t.Log(utils.MustT(t).String(utils.PrettySelect(db, "SELECT * FROM somewhere")))
+//
+func PrettySelect(db DB, query string, args ...interface{}) (string, error) {
+	cursor, err := db.Query(query, args...)
+	if err != nil {
+		return "", fmt.Errorf("failed to execute query: %w", err)
+	}
+	defer func() { _ = cursor.Close() }()
+
+	cols, err := cursor.Columns()
+	if err != nil {
+		return "", fmt.Errorf("failed to get columns of result: %w", err)
+	}
+	labelWidth := 0
+	for _, col := range cols {
+		l := len(col)
+		if l > labelWidth {
+			labelWidth = l
+		}
+	}
+
+	var buf bytes.Buffer
+	_, _ = fmt.Fprintf(&buf, "Query: %s\nArguments: %q\n", query, args)
+
+	for rowId := 0; cursor.Next(); rowId++ {
+		rawRow := make([]interface{}, len(cols))
+		scanRow := make([]interface{}, len(cols))
+
+		for i := range cols {
+			scanRow[i] = &rawRow[i]
+		}
+
+		err := cursor.Scan(scanRow...)
+		if err != nil {
+			return "", fmt.Errorf("failed to scan row of result: %w", err)
+		}
+
+		_, _ = fmt.Fprintln(&buf)
+		for i := range cols {
+			_, _ = fmt.Fprintf(&buf, "[%d] %"+strconv.Itoa(labelWidth)+"s: %s\n",
+				rowId, cols[i], prettyFormatValue(rawRow[i]))
+		}
+	}
+
+	return buf.String(), nil
+}
+
+// prettyFormatValue pretty-prints a value received from the database.
+func prettyFormatValue(value interface{}) string {
+	switch v := value.(type) {
+	case []byte:
+		h := "0x" + hex.EncodeToString(v)
+		s := fmt.Sprintf("%q", v)
+		if len(h) < len(s) {
+			return h
+		} else {
+			return s
+		}
+	case string:
+		return fmt.Sprintf("%q", v)
+	default:
+		return fmt.Sprint(v)
+	}
+}

--- a/utils/must.go
+++ b/utils/must.go
@@ -1,8 +1,36 @@
 package utils
 
+import (
+	"testing"
+)
+
+// MustString panics if err != nil and returns s otherwise.
 func MustString(s string, err error) string {
 	if err != nil {
 		panic(err)
+	} else {
+		return s
+	}
+}
+
+// mustT wraps a testing.TB to implement receiver functions on it.
+type mustT struct {
+	t testing.TB
+}
+
+// MustT returns a struct with receiver functions that fail the given testing.TB on errors.
+//
+// For example, MustT(t).String(fn()), where fn is of type func() (string, error), returns the string returned by
+// fn if it did not return an error, or calls t.Fatal(err) otherwise.
+func MustT(t testing.TB) mustT {
+	return mustT{t: t}
+}
+
+// String calls t.Fatal(err) on the testing.TB passed to MustT if err != nil, otherwise it returns s.
+func (m mustT) String(s string, err error) string {
+	if err != nil {
+		m.t.Fatal(err)
+		return ""
 	} else {
 		return s
 	}


### PR DESCRIPTION
Example usage:
```go
	t.Logf("\n%s", utils.MustT(t).String(utils.PrettySelect(db, db.Rebind(
		"SELECT h.event_time, h.event_type, host.name, h.downtime_history_id FROM history h"+
		" JOIN host ON host.id = h.host_id"+
		" WHERE host.name = ?"+
		" ORDER BY h.event_time"), hostname)))
	t.Logf("\n%s", utils.MustT(t).String(utils.PrettySelect(db, db.Rebind(
		"SELECT h.downtime_id, h.entry_time, h.start_time, h.end_time, h.has_been_cancelled, h.cancel_time"+
		" FROM downtime_history h"+
		" JOIN host ON host.id = h.host_id"+
		" WHERE host.name = ?"+
		" ORDER BY h.downtime_id"), hostname)))
```

Example result:
```
=== CONT  TestHistory/SingleNode/Downtime
    history_test.go:310: 
        Query: SELECT h.event_time, h.event_type, host.name, h.downtime_history_id FROM history h JOIN host ON host.id = h.host_id WHERE host.name = $1 ORDER BY h.event_time
        Arguments: ["TestHistory-SingleNode-Downtime-host-1"]
        
        [0]          event_time: 1637849777000
        [0]          event_type: "downtime_start"
        [0]                name: "TestHistory-SingleNode-Downtime-host-1"
        [0] downtime_history_id: 0x4fb3bbcaf6393ea3704e10efacd4c8bbd42cbcaf
        
        [1]          event_time: 1637849777976
        [1]          event_type: "downtime_end"
        [1]                name: "TestHistory-SingleNode-Downtime-host-1"
        [1] downtime_history_id: 0x4fb3bbcaf6393ea3704e10efacd4c8bbd42cbcaf
    history_test.go:315: 
        Query: SELECT h.downtime_id, h.entry_time, h.start_time, h.end_time, h.has_been_cancelled, h.cancel_time FROM downtime_history h JOIN host ON host.id = h.host_id WHERE host.name = $1 ORDER BY h.downtime_id
        Arguments: ["TestHistory-SingleNode-Downtime-host-1"]
        
        [0]        downtime_id: 0x4fb3bbcaf6393ea3704e10efacd4c8bbd42cbcaf
        [0]         entry_time: 1637849777961
        [0]         start_time: 1637849777000
        [0]           end_time: 1637853377000
        [0] has_been_cancelled: "y"
        [0]        cancel_time: 1637849777976

```