### PR TITLE
Allow an Icinga 2 instance to write to multiple Redis servers

### DIFF
--- a/internal/services/icinga2/docker.go
+++ b/internal/services/icinga2/docker.go
@@ -173,19 +173,6 @@ func (n *dockerInstance) WriteConfig(file string, data []byte) {
 
 func (n *dockerInstance) EnableIcingaDb(redis services.RedisServerBase) {
 	services.Icinga2{Icinga2Base: n}.WriteIcingaDbConf(redis)
-
-	stdout := utils.NewLineWriter(func(line []byte) {
-		n.logger.Debug("exec stdout", zap.ByteString("line", line))
-	})
-	stderr := utils.NewLineWriter(func(line []byte) {
-		n.logger.Error("exec stderr", zap.ByteString("line", line))
-	})
-
-	err := utils.DockerExec(context.Background(), n.icinga2Docker.dockerClient, n.logger, n.containerId,
-		[]string{"icinga2", "feature", "enable", "icingadb"}, nil, stdout, stderr)
-	if err != nil {
-		panic(err)
-	}
 }
 
 func (n *dockerInstance) Cleanup() {

--- a/services/icinga2.go
+++ b/services/icinga2.go
@@ -119,5 +119,5 @@ func (i Icinga2) WriteIcingaDbConf(r RedisServerBase) {
 	if err != nil {
 		panic(err)
 	}
-	i.WriteConfig("etc/icinga2/features-available/icingadb.conf", b.Bytes())
+	i.WriteConfig(fmt.Sprintf("etc/icinga2/features-enabled/icingadb_%s_%s.conf", r.Host(), r.Port()), b.Bytes())
 }

--- a/services/icinga2_icingadb.conf
+++ b/services/icinga2_icingadb.conf
@@ -1,4 +1,4 @@
-object IcingaDB "icingadb" {
+object IcingaDB "icingadb_{{.Host}}_{{.Port}}" {
 	host = "{{.Host}}"
 	port = "{{.Port}}"
 }


### PR DESCRIPTION
This allows `Icinga2.EnableIcingaDb(r)` to be called with different Redis servers `r` resulting in Icinga2 writing to all of them.