### PR TITLE
Log docker error reason

### DIFF
--- a/internal/services/icingadb/docker_binary.go
+++ b/internal/services/icingadb/docker_binary.go
@@ -136,7 +136,7 @@ func (i *dockerBinaryCreator) CreateIcingaDb(
 
 	err = i.dockerClient.ContainerStart(context.Background(), cont.ID, types.ContainerStartOptions{})
 	if err != nil {
-		inst.logger.Fatal("failed to start container")
+		inst.logger.Fatal("failed to start container", zap.Error(err))
 	}
 	inst.logger.Debug("started container")
 

--- a/internal/services/icingadb/docker_binary.go
+++ b/internal/services/icingadb/docker_binary.go
@@ -118,7 +118,7 @@ func (i *dockerBinaryCreator) CreateIcingaDb(
 		},
 	}, nil, containerName)
 	if err != nil {
-		inst.logger.Fatal("failed to create icingadb container")
+		inst.logger.Fatal("failed to create icingadb container", zap.Error(err))
 	}
 	inst.containerId = cont.ID
 	inst.logger = inst.logger.With(zap.String("container-id", cont.ID))

--- a/internal/services/redis/docker.go
+++ b/internal/services/redis/docker.go
@@ -82,7 +82,7 @@ func (r *dockerCreator) CreateRedisServer() services.RedisServerBase {
 
 	err = r.dockerClient.ContainerStart(context.Background(), cont.ID, types.ContainerStartOptions{})
 	if err != nil {
-		logger.Fatal("failed to start container")
+		logger.Fatal("failed to start container", zap.Error(err))
 	}
 	logger.Debug("started container")
 


### PR DESCRIPTION
This PR adds missing Docker errors to the logs so we can actually see why a command failed.