### PR TITLE
Make Docker images configurable

### DIFF
--- a/internal/services/icinga2/docker.go
+++ b/internal/services/icinga2/docker.go
@@ -53,7 +53,7 @@ func (i *dockerCreator) CreateIcinga2(name string) services.Icinga2Base {
 		panic(err)
 	}
 
-	dockerImage := "icinga/icinga2:master"
+	dockerImage := utils.GetEnvDefault("ICINGA_TESTING_ICINGA2_IMAGE", "icinga/icinga2:master")
 	err = utils.DockerImagePull(context.Background(), logger, i.dockerClient, dockerImage, false)
 	if err != nil {
 		panic(err)

--- a/internal/services/mysql/docker.go
+++ b/internal/services/mysql/docker.go
@@ -32,7 +32,7 @@ func NewDockerCreator(logger *zap.Logger, dockerClient *client.Client, container
 		panic(err)
 	}
 
-	dockerImage := "mysql:latest"
+	dockerImage := utils.GetEnvDefault("ICINGA_TESTING_MYSQL_IMAGE", "mysql:latest")
 	err = utils.DockerImagePull(context.Background(), logger, dockerClient, dockerImage, false)
 	if err != nil {
 		panic(err)

--- a/internal/services/postgresql/docker.go
+++ b/internal/services/postgresql/docker.go
@@ -32,7 +32,7 @@ func NewDockerCreator(logger *zap.Logger, dockerClient *client.Client, container
 		panic(err)
 	}
 
-	dockerImage := "postgres:latest"
+	dockerImage := utils.GetEnvDefault("ICINGA_TESTING_PGSQL_IMAGE", "postgres:latest")
 	err = utils.DockerImagePull(context.Background(), logger, dockerClient, dockerImage, false)
 	if err != nil {
 		panic(err)

--- a/internal/services/redis/docker.go
+++ b/internal/services/redis/docker.go
@@ -49,7 +49,7 @@ func (r *dockerCreator) CreateRedisServer() services.RedisServerBase {
 		panic(err)
 	}
 
-	dockerImage := "redis:latest"
+	dockerImage := utils.GetEnvDefault("ICINGA_TESTING_REDIS_IMAGE", "redis:latest")
 	err = utils.DockerImagePull(context.Background(), logger, r.dockerClient, dockerImage, false)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
With this commit, the following environment variables can be set to control which image is used when the corresponding containers are started:
- ICINGA_TESTING_ICINGA2_IMAGE
- ICINGA_TESTING_MYSQL_IMAGE
- ICINGA_TESTING_PGSQL_IMAGE
- ICINGA_TESTING_REDIS_IMAGE

Will probably be useful for https://github.com/Icinga/icingadb/pull/247 soon.

fixes #16