### PR TITLE
Enable binary_parameters for PostgreSQL

### DIFF
--- a/services/postgresql.go
+++ b/services/postgresql.go
@@ -51,7 +51,7 @@ func (p PostgresqlDatabase) DSN() string {
 		User:     url.UserPassword(p.Username(), p.Password()),
 		Host:     net.JoinHostPort(p.Host(), p.Port()),
 		Path:     "/" + url.PathEscape(p.Database()),
-		RawQuery: "sslmode=disable",
+		RawQuery: "sslmode=disable&binary_parameters=yes",
 	}
 
 	return u.String()


### PR DESCRIPTION
Needed to pass []byte to the database.

This parameter is already used in Icinga DB:
https://github.com/Icinga/icingadb/blob/1da2dfdcce2df16970af99b80c48729152d2577d/pkg/config/database.go#L79