### PR TITLE
Improve compatibility for different database versions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/icinga/icinga-testing
 go 1.16
 
 require (
+	github.com/Icinga/go-libs v0.0.0-20220420130327-ef58ad52edd8
 	github.com/Microsoft/go-winio v0.5.0 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/containerd/containerd v1.5.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -37,6 +37,8 @@ github.com/Azure/go-autorest/logger v0.2.0/go.mod h1:T9E3cAhj2VqvPOtCYAvby9aBXkZ
 github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBpUA79WCAKPPZVC2DeU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/Icinga/go-libs v0.0.0-20220420130327-ef58ad52edd8 h1:hG4Y/LPERK9i+P8/jnYlq9PeDd9deIkwEWOIimDU3uk=
+github.com/Icinga/go-libs v0.0.0-20220420130327-ef58ad52edd8/go.mod h1:xlgU55MKs/vIg1fMlAEBSrslahYayZNwjXvf3w1dvyA=
 github.com/Microsoft/go-winio v0.4.11/go.mod h1:VhR8bwka0BXejwEJY73c50VrPtXAaKcyvVC4A4RozmA=
 github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=
 github.com/Microsoft/go-winio v0.4.15-0.20190919025122-fc70bd9a86b5/go.mod h1:tTuCMEN+UleMWgg9dVx4Hu52b1bJo+59jBh3ajtinzw=
@@ -59,6 +61,7 @@ github.com/Microsoft/hcsshim/test v0.0.0-20201218223536-d3e5debf77da/go.mod h1:5
 github.com/Microsoft/hcsshim/test v0.0.0-20210227013316-43a75bb4edd3/go.mod h1:mw7qgWloBUl75W/gVH3cQszUg1+gUITj7D6NY7ywVnY=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
+github.com/PuerkitoBio/goquery v1.5.1/go.mod h1:GsLWisAFVj4WgDibEWF4pvYnkVQBpKBKeU+7zCJoLcc=
 github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/Shopify/logrus-bugsnag v0.0.0-20171204204709-577dee27f20d/go.mod h1:HI8ITrYtUY+O+ZhtlqUnD8+KwNPOyugEhfP9fdUIaEQ=
@@ -67,6 +70,7 @@ github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuy
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alexflint/go-filemutex v0.0.0-20171022225611-72bdc8eae2ae/go.mod h1:CgnQgUtFrFz9mxFNtED3jI5tLDjKlOM+oUF/sTk6ps0=
+github.com/andybalholm/cascadia v1.1.0/go.mod h1:GsXiBklL0woXo1j/WYWtSYYC4ouU9PqHO0sqidkEA4Y=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
@@ -428,6 +432,8 @@ github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaO
 github.com/mattn/go-isatty v0.0.4/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mattn/go-shellwords v1.0.3/go.mod h1:3xCvwCdWdlDJUrvuMn7Wuy9eWs4pE8vqg+NOMyg4B2o=
+github.com/mattn/go-sqlite3 v1.14.0 h1:mLyGNKR8+Vv9CAU7PphKa2hkEqxxhn8i32J6FPj1/QA=
+github.com/mattn/go-sqlite3 v1.14.0/go.mod h1:JIl7NbARA7phWnGvh0LKTyg7S9BA+6gx71ShQilpsus=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
 github.com/miekg/pkcs11 v1.0.3/go.mod h1:XsNlhZGX73bx86s2hdc/FuaLm2CPZJemRLMA+WTFxgs=
@@ -688,6 +694,7 @@ golang.org/x/mod v0.1.1-0.20191107180719-034126e5016b/go.mod h1:QqPTAvyqsEbceGzB
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+golang.org/x/net v0.0.0-20180218175443-cbe0f9307d01/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=

--- a/internal/services/mysql/docker.go
+++ b/internal/services/mysql/docker.go
@@ -42,7 +42,7 @@ func NewDockerCreator(logger *zap.Logger, dockerClient *client.Client, container
 	cont, err := dockerClient.ContainerCreate(context.Background(), &container.Config{
 		ExposedPorts: nil,
 		Env:          []string{"MYSQL_ROOT_PASSWORD=" + rootPassword},
-		Cmd:          nil,
+		Cmd:          []string{"--disable-log-bin"},
 		Image:        dockerImage,
 	}, nil, &network.NetworkingConfig{
 		EndpointsConfig: map[string]*network.EndpointSettings{

--- a/internal/services/mysql/root_connection.go
+++ b/internal/services/mysql/root_connection.go
@@ -40,7 +40,7 @@ func (m *rootConnection) CreateMysqlDatabase() services.MysqlDatabaseBase {
 
 	// I'm sorry for making the following three queries look like they are prone to SQL-injections, but it seems like
 	// MySQL does not support prepared statements for these queries. The values are not user-controlled, so it's fine.
-	_, err := m.db.Exec(fmt.Sprintf("CREATE USER %s IDENTIFIED WITH mysql_native_password BY '%s'", username, password))
+	_, err := m.db.Exec(fmt.Sprintf("CREATE USER %s IDENTIFIED BY '%s'", username, password))
 	if err != nil {
 		panic(err)
 	}

--- a/internal/services/mysql/root_connection.go
+++ b/internal/services/mysql/root_connection.go
@@ -52,7 +52,8 @@ func (m *rootConnection) CreateMysqlDatabase() services.MysqlDatabaseBase {
 	if err != nil {
 		panic(err)
 	}
-	_, err = m.db.Exec(fmt.Sprintf("GRANT SESSION_VARIABLES_ADMIN ON *.* TO %s", username))
+	// SESSION_VARIABLES_ADMIN is only needed and supported on MySQL 8+, that magic comments only executes it there.
+	_, err = m.db.Exec(fmt.Sprintf("/*!80000 GRANT SESSION_VARIABLES_ADMIN ON *.* TO %s */", username))
 	if err != nil {
 		panic(err)
 	}

--- a/internal/services/postgresql/docker.go
+++ b/internal/services/postgresql/docker.go
@@ -83,9 +83,12 @@ func NewDockerCreator(logger *zap.Logger, dockerClient *client.Client, container
 		containerName:  containerName,
 	}
 
+	db, err := d.rootConnection.openAsRoot("postgres")
+	defer func() { _ = db.Close() }()
+
 	for attempt := 1; ; attempt++ {
 		time.Sleep(1 * time.Second)
-		err := d.rootConnection.db.Ping()
+		err := db.Ping()
 		if err == nil {
 			break
 		} else if attempt == 60 {

--- a/services/postgresql.go
+++ b/services/postgresql.go
@@ -6,8 +6,6 @@ import (
 	"net"
 	"net/url"
 	"os"
-	"regexp"
-	"strings"
 )
 
 type PostgresqlDatabaseBase interface {
@@ -77,14 +75,7 @@ func (p PostgresqlDatabase) ImportIcingaDbSchema() {
 	if err != nil {
 		panic(err)
 	}
-	// duplicated from https://github.com/Icinga/docker-icingadb/blob/master/entrypoint/main.go
-	sqlComment := regexp.MustCompile(`(?m)^--.*`)
-	sqlStmtSep := regexp.MustCompile(`(?m);$`)
-	for _, ddl := range sqlStmtSep.Split(string(sqlComment.ReplaceAll(schema, nil)), -1) {
-		if ddl = strings.TrimSpace(ddl); ddl != "" {
-			if _, err := db.Exec(ddl); err != nil {
-				panic(err)
-			}
-		}
+	if _, err := db.Exec(string(schema)); err != nil {
+		panic(err)
 	}
 }


### PR DESCRIPTION
This PR adds all kinds of compatibility workarounds so that https://github.com/Icinga/icingadb/pull/247 can run it's tests on many different MySQL/MariaDB/PostgreSQL versions. Please refer to the individual commits with their description for an explanation of the changes.

### Blocked by
* https://github.com/Icinga/go-libs/pull/3

### TODO
* [x] After https://github.com/Icinga/go-libs/pull/3 was merged, update this PR to use the new version given by the merge commit.