### PR TITLE
Allow to set additional raw Icinga DB YAML config

### DIFF
--- a/internal/services/icingadb/docker_binary.go
+++ b/internal/services/icingadb/docker_binary.go
@@ -56,6 +56,7 @@ func NewDockerBinaryCreator(
 func (i *dockerBinaryCreator) CreateIcingaDb(
 	redis services.RedisServerBase,
 	rdb services.RelationalDatabase,
+	options ...services.IcingaDbOption,
 ) services.IcingaDbBase {
 	inst := &dockerBinaryInstance{
 		info: info{
@@ -70,8 +71,11 @@ func (i *dockerBinaryCreator) CreateIcingaDb(
 	if err != nil {
 		panic(err)
 	}
-	err = services.IcingaDb{IcingaDbBase: inst}.WriteConfig(configFile)
-	if err != nil {
+	idb := &services.IcingaDb{IcingaDbBase: inst}
+	for _, option := range options {
+		option(idb)
+	}
+	if err = idb.WriteConfig(configFile); err != nil {
 		panic(err)
 	}
 	inst.configFileName = configFile.Name()

--- a/internal/services/icingadb/icingadb.go
+++ b/internal/services/icingadb/icingadb.go
@@ -6,7 +6,7 @@ import (
 )
 
 type Creator interface {
-	CreateIcingaDb(redis services.RedisServerBase, mysql services.RelationalDatabase) services.IcingaDbBase
+	CreateIcingaDb(redis services.RedisServerBase, mysql services.RelationalDatabase, options ...services.IcingaDbOption) services.IcingaDbBase
 	Cleanup()
 }
 

--- a/it.go
+++ b/it.go
@@ -260,15 +260,15 @@ func (it *IT) getIcingaDb() icingadb.Creator {
 //
 // It expects the ICINGA_TESTING_ICINGADB_BINARY environment variable to be set to the path of a precompiled icingadb
 // binary which is then started in a new Docker container when this function is called.
-func (it *IT) IcingaDbInstance(redis services.RedisServer, rdb services.RelationalDatabase) services.IcingaDb {
-	return services.IcingaDb{IcingaDbBase: it.getIcingaDb().CreateIcingaDb(redis, rdb)}
+func (it *IT) IcingaDbInstance(redis services.RedisServer, rdb services.RelationalDatabase, options ...services.IcingaDbOption) services.IcingaDb {
+	return services.IcingaDb{IcingaDbBase: it.getIcingaDb().CreateIcingaDb(redis, rdb, options...)}
 }
 
 // IcingaDbInstanceT creates a new Icinga DB instance and registers its cleanup function with testing.T.
 func (it *IT) IcingaDbInstanceT(
-	t testing.TB, redis services.RedisServer, rdb services.RelationalDatabase,
+	t testing.TB, redis services.RedisServer, rdb services.RelationalDatabase, options ...services.IcingaDbOption,
 ) services.IcingaDb {
-	i := it.IcingaDbInstance(redis, rdb)
+	i := it.IcingaDbInstance(redis, rdb, options...)
 	t.Cleanup(i.Cleanup)
 	return i
 }

--- a/services/icingadb.go
+++ b/services/icingadb.go
@@ -20,6 +20,7 @@ type IcingaDbBase interface {
 // IcingaDb wraps the IcingaDbBase interface and adds some more helper functions.
 type IcingaDb struct {
 	IcingaDbBase
+	config string
 }
 
 //go:embed icingadb.yml
@@ -28,4 +29,19 @@ var icingadbYmlTemplate = template.Must(template.New("icingadb.yml").Parse(icing
 
 func (i IcingaDb) WriteConfig(w io.Writer) error {
 	return icingadbYmlTemplate.Execute(w, i)
+}
+
+// Config returns additional raw YAML configuration, if any.
+func (i IcingaDb) Config() string {
+	return i.config
+}
+
+// IcingaDbOption configures IcingaDb.
+type IcingaDbOption func(*IcingaDb)
+
+// WithIcingaDbConfig sets additional raw YAML configuration.
+func WithIcingaDbConfig(config string) func(*IcingaDb) {
+	return func(db *IcingaDb) {
+		db.config = config
+	}
 }

--- a/services/icingadb.yml
+++ b/services/icingadb.yml
@@ -10,3 +10,4 @@ redis:
 logging:
   level: debug
   interval: 1s
+{{.Config}}


### PR DESCRIPTION
This PR introduces the functionality to set additional raw Icinga DB YAML configuration via an options function. Also, the PostgreSQL user is created with SUPERUSER privileges because Icinga DB retention tests require elevated privileges.