### PR TITLE
Add Go package docs including description of environment variables

### DIFF
--- a/it.go
+++ b/it.go
@@ -1,3 +1,17 @@
+// Package icingatesting contains helpers to facilitate performing integration tests between components of the Icinga
+// stack using the Go testing package. The general idea is to write test cases in Go that can dynamically spawn
+// individual components as required, connect them and then perform checks on this setup. This is implemented by using
+// the Docker API to start and stop containers locally as required by the tests.
+//
+// The following environment variables are used by icinga-testing:
+//  - ICINGA_TESTING_ICINGA2_IMAGE: Icinga 2 container image to use (default: "icinga/icinga2:master")
+//  - ICINGA_TESTING_MYSQL_IMAGE: MySQL/MariaDB container image to use (default: "mysql:latest")
+//  - ICINGA_TESTING_PGSQL_IMAGE: PostgreSQL container image to use (default: "postgres:latest")
+//  - ICINGA_TESTING_REDIS_IMAGE: Redis container image to use (default: "redis:latest")
+//  - ICINGA_TESTING_ICINGADB_BINARY: Path to the Icinga DB binary to test. It will run in a container and therefore
+//                                    must be compiled using CGO_ENABLED=0
+//  - ICINGA_TESTING_ICINGADB_SCHEMA_MYSQL: Path to the full Icinga DB schema file for MySQL/MariaDB
+//  - ICINGA_TESTING_ICINGADB_SCHEMA_PGSQL: Path to the full Icinga DB schema file for PostgreSQL
 package icingatesting
 
 import (


### PR DESCRIPTION
At the moment, the environment variables used are scattered throughout the code with no central documentation. This PR adds a list to the Go package documentation. I put it there instead of some new markdown file as the intended user of this documentation is the same one writing the tests using this package, so I think it makes sense to document both in the same place. This adds some duplication with the README file (the package description is basically taken from there).

This does not render super pretty at the moment but it gets the job done and there is hope that this will improve at some point with https://github.com/golang/go/issues/51082.

![Screenshot of the rendered documentation](https://user-images.githubusercontent.com/18552/168276188-8cb5d25c-ae97-48df-bf15-880e5b987f7e.png)