### PR TITLE
Initial support for Icinga Notifications

### DIFF
--- a/internal/services/icinga2/docker.go
+++ b/internal/services/icinga2/docker.go
@@ -189,6 +189,10 @@ func (n *dockerInstance) EnableIcingaDb(redis services.RedisServerBase) {
 	services.Icinga2{Icinga2Base: n}.WriteIcingaDbConf(redis)
 }
 
+func (n *dockerInstance) EnableIcingaNotifications(notis services.IcingaNotificationsBase) {
+	services.Icinga2{Icinga2Base: n}.WriteIcingaNotificationsConf(notis)
+}
+
 func (n *dockerInstance) Cleanup() {
 	n.icinga2Docker.runningMutex.Lock()
 	delete(n.icinga2Docker.running, n)

--- a/internal/services/notifications/notifications.go
+++ b/internal/services/notifications/notifications.go
@@ -1,0 +1,33 @@
+package notifications
+
+import (
+	"github.com/icinga/icinga-testing/services"
+)
+
+// defaultPort of the Icinga Notifications Web Listener.
+const defaultPort string = "5680"
+
+type Creator interface {
+	CreateIcingaNotifications(rdb services.RelationalDatabase, options ...services.IcingaNotificationsOption) services.IcingaNotificationsBase
+	Cleanup()
+}
+
+// info provides a partial implementation of the services.IcingaNotificationsBase interface.
+type info struct {
+	host string
+	port string
+
+	rdb services.RelationalDatabase
+}
+
+func (i *info) Host() string {
+	return i.host
+}
+
+func (i *info) Port() string {
+	return i.port
+}
+
+func (i *info) RelationalDatabase() services.RelationalDatabase {
+	return i.rdb
+}

--- a/services/icinga2.go
+++ b/services/icinga2.go
@@ -40,6 +40,9 @@ type Icinga2Base interface {
 	// EnableIcingaDb enables the icingadb feature on this node using the connection details of redis.
 	EnableIcingaDb(redis RedisServerBase)
 
+	// EnableIcingaNotifications enables the Icinga Notifications integration with the custom configuration.
+	EnableIcingaNotifications(IcingaNotificationsBase)
+
 	// Cleanup stops the node and removes everything that was created to start this node.
 	Cleanup()
 }
@@ -127,4 +130,17 @@ func (i Icinga2) WriteIcingaDbConf(r RedisServerBase) {
 		panic(err)
 	}
 	i.WriteConfig(fmt.Sprintf("etc/icinga2/features-enabled/icingadb_%s_%s.conf", r.Host(), r.Port()), b.Bytes())
+}
+
+//go:embed icinga2_icinga_notifications.conf
+var icinga2IcingaNotificationsConfRawTemplate string
+var icinga2IcingaNotificationsConfTemplate = template.Must(template.New("icinga-notifications.conf").Parse(icinga2IcingaNotificationsConfRawTemplate))
+
+func (i Icinga2) WriteIcingaNotificationsConf(notis IcingaNotificationsBase) {
+	b := bytes.NewBuffer(nil)
+	err := icinga2IcingaNotificationsConfTemplate.Execute(b, notis)
+	if err != nil {
+		panic(err)
+	}
+	i.WriteConfig("etc/icinga2/features-enabled/icinga_notifications.conf", b.Bytes())
 }

--- a/services/icinga2_icinga_notifications.conf
+++ b/services/icinga2_icinga_notifications.conf
@@ -1,0 +1,290 @@
+const IcingaNotificationsProcessEventUrl = "http://{{.Host}}:{{.Port}}/process-event"
+const IcingaNotificationsIcingaWebUrl = "http://localhost/icingaweb2"
+const IcingaNotificationsAuth = "source-1:correct horse battery staple"
+
+// urlencode a string loosely based on RFC 3986.
+//
+// Char replacement will be performed through a simple lookup table based on
+// the RFC's chapters 2.2 and 2.3. This, however, is limited to ASCII.
+function urlencode(str) {
+	var replacement = {
+		// gen-delims
+		":" = "%3A", "/" = "%2F", "?" = "%3F", "#" = "%23", "[" = "%5B", "]" = "%5D", "@" = "%40"
+
+		// sub-delims
+		"!" = "%21", "$" = "%24", "&" = "%26", "'" = "%27", "(" = "%28", ")" = "%29"
+		"*" = "%2A", "+" = "%2B", "," = "%2C", ";" = "%3B", "=" = "%3D"
+
+		// additionals based on !unreserved
+		"\n" = "%0A", "\r" = "%0D", " " = "%20", "\"" = "%22"
+	}
+
+	var pos = 0
+	var out = ""
+
+	while (pos < str.len()) {
+		var cur = str.substr(pos, 1)
+		out += replacement.contains(cur) ? replacement.get(cur) : cur
+		pos += 1
+	}
+
+	return out
+}
+
+object User "icinga-notifications" {
+	# Workaround, types filter here must exclude Problem, otherwise no Acknowledgement notifications are sent.
+	# https://github.com/Icinga/icinga2/issues/9739
+	types = [ Acknowledgement ]
+}
+
+var baseBody = {
+	"curl" = {
+		order = -1
+		set_if = {{`{{ true }}`}}
+		skip_key = true
+		value = {{`{{
+			// Only send events that have either severity or type set, otherwise make it a no-op by executing true.
+			// This is used for preventing the EventCommand from sending invalid events for soft states.
+			(len(macro("$event_severity$")) > 0 || len(macro("$event_type$")) > 0) ? "curl" : "true"
+		}}`}}
+	}
+	"--user" = { value = IcingaNotificationsAuth }
+	"--fail" = { set_if = true }
+	"--silent" = { set_if = true }
+	"--show-error" = { set_if = true }
+	"url" = {
+		skip_key = true
+		value = IcingaNotificationsProcessEventUrl
+	}
+}
+
+var hostBody = baseBody + {
+	"-d" = {{`{{
+		var args = {}
+		args.tags.host = macro("$event_hostname$")
+		args.name = macro("$event_object_name$")
+		args.username = macro("$event_author$")
+		args.message = macro("$event_message$")
+		args.url = IcingaNotificationsIcingaWebUrl + "/icingadb/host?name=" + urlencode(macro("$host.name$"))
+
+		var type = macro("$event_type$")
+		if (len(type) > 0) {
+			args.type = type
+		}
+
+		var severity = macro("$event_severity$")
+		if (len(severity) > 0) {
+			args.severity = severity
+		}
+
+		var extraTags = macro("$event_extra_tags$")
+		if (extraTags.len() > 0) {
+			args.extra_tags = extraTags
+		}
+
+		return Json.encode(args)
+	}}`}}
+}
+
+var hostExtraTags = {{`{{
+	var tags = {}
+	for (group in host.groups) {
+		tags.set("hostgroup/" + group, null)
+	}
+
+	return tags
+}}`}}
+
+object NotificationCommand "icinga-notifications-host" use(hostBody, hostExtraTags) {
+	command = [ /* full command line generated from arguments */ ]
+
+	arguments = hostBody
+
+	vars += {
+		event_hostname = "$host.name$"
+		event_author = "$notification.author$"
+		event_message = "$notification.comment$"
+		event_object_name = "$host.display_name$"
+		event_extra_tags = hostExtraTags
+	}
+
+	vars.event_type = {{`{{
+		if (macro("$notification.type$") == "ACKNOWLEDGEMENT") {
+			return "acknowledgement"
+		}
+
+		return ""
+	}}`}}
+
+	vars.event_severity = {{`{{
+		if (macro("$notification.type$") != "ACKNOWLEDGEMENT") {
+			return macro("$host.state$") == "DOWN" ? "crit" : "ok"
+		}
+
+		return ""
+	}}`}}
+}
+
+object EventCommand "icinga-notifications-host-events" use(hostBody, hostExtraTags) {
+	command = [ /* full command line generated from arguments */ ]
+
+	arguments = hostBody
+
+	vars += {
+		event_hostname = "$host.name$"
+		event_author = ""
+		event_message = "$host.output$"
+		event_object_name = "$host.display_name$"
+		event_extra_tags = hostExtraTags
+	}
+
+	vars.event_severity = {{`{{
+		if (macro("$host.state_type$") == "HARD") {
+			return macro("$host.state$") == "DOWN" ? "crit" : "ok"
+		}
+
+		return ""
+	}}`}}
+}
+
+template Host "generic-icinga-notifications-host" default {
+	event_command = "icinga-notifications-host-events"
+}
+
+apply Notification "icinga-notifications-forwarder" to Host {
+	command = "icinga-notifications-host"
+
+	types = [ Acknowledgement ]
+
+	users = [ "icinga-notifications" ]
+
+	assign where true
+}
+
+var serviceBody = baseBody + {
+	"-d" = {{`{{
+		var args = {}
+		args.tags.host = macro("$event_hostname$")
+		args.tags.service = macro("$event_servicename$")
+		args.name = macro("$event_object_name$")
+		args.username = macro("$event_author$")
+		args.message = macro("$event_message$")
+		args.url = IcingaNotificationsIcingaWebUrl + "/icingadb/service?name=" + urlencode(macro("$service.name$")) + "&host.name=" + urlencode(macro("$service.host.name$"))
+
+		var type = macro("$event_type$")
+		if (len(type) > 0) {
+			args.type = type
+		}
+
+		var severity = macro("$event_severity$")
+		if (len(severity) > 0) {
+			args.severity = severity
+		}
+
+		var extraTags = macro("$event_extra_tags$")
+		if (extraTags.len() > 0) {
+			args.extra_tags = extraTags
+		}
+
+		return Json.encode(args)
+	}}`}}
+}
+
+var serviceExtraTags = {{`{{
+	var tags = {}
+	for (group in service.host.groups) {
+		tags.set("hostgroup/" + group, null)
+	}
+
+	for (group in service.groups) {
+		tags.set("servicegroup/" + group, null)
+	}
+
+	return tags
+}}`}}
+
+object NotificationCommand "icinga-notifications-service" use(serviceBody, serviceExtraTags) {
+	command = [ /* full command line generated from arguments */ ]
+
+	arguments = serviceBody
+
+	vars += {
+		event_hostname = "$service.host.name$"
+		event_servicename = "$service.name$"
+		event_author = "$notification.author$"
+		event_message = "$notification.comment$"
+		event_object_name = "$host.display_name$: $service.display_name$"
+		event_extra_tags = serviceExtraTags
+	}
+
+	vars.event_type = {{`{{
+		if (macro("$notification.type$") == "ACKNOWLEDGEMENT") {
+			return "acknowledgement"
+		}
+
+		return ""
+	}}`}}
+
+	vars.event_severity = {{`{{
+		if (macro("$notification.type$") != "ACKNOWLEDGEMENT") {
+			var state = macro("$service.state$")
+			if (state == "OK") {
+				return "ok"
+			} else if (state == "WARNING") {
+				return "warning"
+			} else if (state == "CRITICAL") {
+				return "crit"
+			} else { // Unknown
+				return "err"
+			}
+		}
+
+		return ""
+	}}`}}
+}
+
+object EventCommand "icinga-notifications-service-events" use(serviceBody, serviceExtraTags) {
+	command = [ /* full command line generated from arguments */ ]
+
+	arguments = serviceBody
+
+	vars += {
+		event_hostname = "$service.host.name$"
+		event_servicename = "$service.name$"
+		event_author = ""
+		event_message = "$service.output$"
+		event_object_name = "$host.display_name$: $service.display_name$"
+		event_extra_tags = serviceExtraTags
+	}
+
+	vars.event_severity = {{`{{
+		if (macro("$service.state_type$") == "HARD") {
+			var state = macro("$service.state$")
+			if (state == "OK") {
+				return "ok"
+			} else if (state == "WARNING") {
+				return "warning"
+			} else if (state == "CRITICAL") {
+				return "crit"
+			} else { // Unknown
+				return "err"
+			}
+		}
+
+		return ""
+	}}`}}
+}
+
+template Service "generic-icinga-notifications-service" default {
+	event_command = "icinga-notifications-service-events"
+}
+
+apply Notification "icinga-notifications-forwarder" to Service {
+	command = "icinga-notifications-service"
+
+	types = [ Acknowledgement ]
+
+	users = [ "icinga-notifications" ]
+
+	assign where true
+}

--- a/services/icinga_notifications.go
+++ b/services/icinga_notifications.go
@@ -1,0 +1,50 @@
+package services
+
+import (
+	_ "embed"
+	"io"
+	"text/template"
+)
+
+type IcingaNotificationsBase interface {
+	// Host returns the host on which Icinga Notification's listener can be reached.
+	Host() string
+
+	// Port return the port on which Icinga Notification's listener can be reached.
+	Port() string
+
+	// RelationalDatabase returns the instance information of the relational database this instance is using.
+	RelationalDatabase() RelationalDatabase
+
+	// Cleanup stops the instance and removes everything that was created to start it.
+	Cleanup()
+}
+
+// IcingaNotifications wraps the IcingaNotificationsBase interface and adds some more helper functions.
+type IcingaNotifications struct {
+	IcingaNotificationsBase
+	config string
+}
+
+//go:embed icinga_notifications.yml
+var icingaNotificationsYmlRawTemplate string
+var icingaNotificationsYmlTemplate = template.Must(template.New("icinga_notifications.yml").Parse(icingaNotificationsYmlRawTemplate))
+
+func (i IcingaNotifications) WriteConfig(w io.Writer) error {
+	return icingaNotificationsYmlTemplate.Execute(w, i)
+}
+
+// Config returns additional raw YAML configuration, if any.
+func (i IcingaNotifications) Config() string {
+	return i.config
+}
+
+// IcingaNotificationsOption configures IcingaNotifications.
+type IcingaNotificationsOption func(*IcingaNotifications)
+
+// WithIcingaNotificationsConfig sets additional raw YAML configuration.
+func WithIcingaNotificationsConfig(config string) func(notifications *IcingaNotifications) {
+	return func(db *IcingaNotifications) {
+		db.config = config
+	}
+}

--- a/services/icinga_notifications.yml
+++ b/services/icinga_notifications.yml
@@ -1,0 +1,16 @@
+listen: ":{{.Port}}"
+channel-plugin-dir: /usr/libexec/icinga-notifications/channel
+
+database:
+  type: {{.RelationalDatabase.IcingaDbType}}
+  host: {{.RelationalDatabase.Host}}
+  port: {{.RelationalDatabase.Port}}
+  database: {{.RelationalDatabase.Database}}
+  user: {{.RelationalDatabase.Username}}
+  password: {{.RelationalDatabase.Password}}
+
+logging:
+  level: debug
+  interval: 1s
+
+{{.Config}}

--- a/services/mysql.go
+++ b/services/mysql.go
@@ -73,3 +73,7 @@ func (m MysqlDatabase) ImportIcingaDbSchema() {
 		}
 	}
 }
+
+func (m MysqlDatabase) ImportIcingaNotificationsSchema() {
+	panic("icinga-notifications does not support MySQL yet")
+}

--- a/services/postgresql.go
+++ b/services/postgresql.go
@@ -59,8 +59,7 @@ func (p PostgresqlDatabase) Open() (*sql.DB, error) {
 	return sql.Open(p.Driver(), p.DSN())
 }
 
-func (p PostgresqlDatabase) ImportIcingaDbSchema() {
-	key := "ICINGA_TESTING_ICINGADB_SCHEMA_PGSQL"
+func (p PostgresqlDatabase) importSchema(key string) {
 	schemaFile, ok := os.LookupEnv(key)
 	if !ok {
 		panic(fmt.Errorf("environment variable %s must be set", key))
@@ -68,7 +67,7 @@ func (p PostgresqlDatabase) ImportIcingaDbSchema() {
 
 	schema, err := os.ReadFile(schemaFile)
 	if err != nil {
-		panic(fmt.Errorf("failed to read icingadb schema file %q: %w", schemaFile, err))
+		panic(fmt.Errorf("failed to read %s schema file %q: %w", key, schemaFile, err))
 	}
 
 	db, err := PostgresqlDatabase{PostgresqlDatabaseBase: p}.Open()
@@ -78,4 +77,12 @@ func (p PostgresqlDatabase) ImportIcingaDbSchema() {
 	if _, err := db.Exec(string(schema)); err != nil {
 		panic(err)
 	}
+}
+
+func (p PostgresqlDatabase) ImportIcingaDbSchema() {
+	p.importSchema("ICINGA_TESTING_ICINGADB_SCHEMA_PGSQL")
+}
+
+func (p PostgresqlDatabase) ImportIcingaNotificationsSchema() {
+	p.importSchema("ICINGA_TESTING_ICINGA_NOTIFICATIONS_SCHEMA_PGSQL")
 }

--- a/services/relational_database.go
+++ b/services/relational_database.go
@@ -28,6 +28,9 @@ type RelationalDatabase interface {
 	// ImportIcingaDbSchema imports the Icinga DB schema into this database.
 	ImportIcingaDbSchema()
 
+	// ImportIcingaNotificationsSchema imports the Icinga Notifications schema into this database.
+	ImportIcingaNotificationsSchema()
+
 	// Cleanup removes the database.
 	Cleanup()
 }


### PR DESCRIPTION
Inspired by the existing code for the Icinga DB, support for Icinga Notifications was added. Thus, there might be some level of code duplication between those two.

The custom Icinga 2 configuration was sourced from the Icinga Notifications repository, but edited to not being parsed as a faulty Go template.

---

This PR initially was #25, but the remote has changed and it seems like I cannot change a PR's originating branch resp. branch location.

Requires #26 to be merged first.