### PR TITLE
Fix compatibility with MySQL 8.0.0 to 8.0.13

### DIFF
--- a/internal/services/mysql/root_connection.go
+++ b/internal/services/mysql/root_connection.go
@@ -52,8 +52,8 @@ func (m *rootConnection) CreateMysqlDatabase() services.MysqlDatabaseBase {
 	if err != nil {
 		panic(err)
 	}
-	// SESSION_VARIABLES_ADMIN is only needed and supported on MySQL 8+, that magic comments only executes it there.
-	_, err = m.db.Exec(fmt.Sprintf("/*!80000 GRANT SESSION_VARIABLES_ADMIN ON *.* TO %s */", username))
+	// SESSION_VARIABLES_ADMIN is only needed and supported on MySQL 8.0.14+, that magic comments only executes it there.
+	_, err = m.db.Exec(fmt.Sprintf("/*!80014 GRANT SESSION_VARIABLES_ADMIN ON *.* TO %s */", username))
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
`SESSION_VARIABLES_ADMIN` wasn't actually introduced in MySQL 8.0.0 but only in 8.0.14.[^1] Use exactly that version in the version comparison to ensure compatibility.

### Tests

Running the Icinga DB integration tests with the following environment variables set:

- `ICINGA_TESTING_MYSQL_IMAGE=mysql:8.0.0`
- `ICINGA_TESTING_MYSQL_IMAGE=mysql:8.0.13`
- `ICINGA_TESTING_MYSQL_IMAGE=mysql:8.0.14`

#### Before

Running in Icinga DB as-is:

8.0.0:

```
panic: Error 1064 (42000): You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'ON *.* TO u1 */' at line 1
```

8.0.13 (yes, the error message got worse):

```
panic: Error 1149 (42000): You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use
```

8.0.14 works fine.

#### After

After adding `replace github.com/icinga/icinga-testing => ../../icinga-testing` to https://github.com/Icinga/icingadb/blob/main/tests/go.mod to use the changed version from this PR: all three versions work fine.

refs https://github.com/Icinga/icingadb/pull/729 (the problem was noticed there)

[^1]: https://dev.mysql.com/doc/refman/8.0/en/privileges-provided.html#priv_session-variables-admin